### PR TITLE
Modifies proxy ARP/NDP device detection to use local host interface I…

### DIFF
--- a/ctctl-netup/ctctl-netup.go
+++ b/ctctl-netup/ctctl-netup.go
@@ -1,5 +1,6 @@
 // +build linux,cgo
 
+// lxc-routednet hook that provides routed network connectivity for LXC containers.
 package main
 
 import (
@@ -11,6 +12,7 @@ import (
 	"io/ioutil"
 	"log"
 	"log/syslog"
+	"net"
 	"os"
 	"os/exec"
 	"strings"
@@ -23,23 +25,26 @@ var (
 func init() {
 	flag.Parse()
 	log.SetFlags(0)
-	syslogWriter, err := syslog.New(syslog.LOG_INFO, "ctctl-netup")
+	syslogWriter, err := syslog.New(syslog.LOG_INFO, "lxc-routednet")
 	if err == nil {
 		log.SetOutput(syslogWriter)
 	}
 }
 
+// gwDev contains the network device name and IPs (v4 and v6) that the container uses as gateways.
 type gwDev struct {
 	dev   string
 	gwIps []string
 }
 
 func main() {
+	//Extract hook arguments from LXC.
 	ctName := flag.Arg(0)
 	context := flag.Arg(2)
 	devType := flag.Arg(3)
 	hostDevName := flag.Arg(4)
 
+	//Load the container's config to get IP information.
 	c, err := lxc.NewContainer(ctName, lxc.DefaultConfigPath())
 	if err != nil {
 		log.Fatalf("Cannot load config for: %s, %s\n", ctName, err.Error())
@@ -57,14 +62,18 @@ func main() {
 	var v6Ips []string
 
 	gwProxyDevs := make(map[string]gwDev)
+
+	//Sections of LXC container config to check for networking config.
 	netPrefixes := []string{"lxc.net", "lxc.network"}
 
 	for _, netPrefix := range netPrefixes {
-		//Check for which network has correct up script
+		//Check for network interfaces configured to use this hook script.
 		for i := 0; i < len(c.ConfigItem(netPrefix)); i++ {
 			upScript := c.ConfigItem(fmt.Sprintf("%s.%d.script.up", netPrefix, i))
 			//Check up script is this program.
 			if strings.HasSuffix(upScript[0], os.Args[0]) {
+
+				//Extract container IPs from config.
 				if netPrefix == "lxc.network" {
 					v4Ips = c.ConfigItem(fmt.Sprintf("%s.%d.ipv4", netPrefix, i))
 					v6Ips = c.ConfigItem(fmt.Sprintf("%s.%d.ipv6", netPrefix, i))
@@ -79,6 +88,7 @@ func main() {
 					gwIps: make([]string, 0),
 				}
 
+				//Extract gateway IPs from config.
 				v4Gws := c.ConfigItem(fmt.Sprintf("%s.%d.ipv4.gateway", netPrefix, i))
 				if v4Gws[0] != "" {
 					gwProxyDev.gwIps = append(gwProxyDev.gwIps, v4Gws[0])
@@ -102,9 +112,9 @@ func main() {
 		log.Fatal("No Gateways defined for CT Dev Ref: ", ctName)
 	}
 
-	ipAddrs := make([]string, 0, 2)
-	cleanIps(v4Ips, &ipAddrs)
-	cleanIps(v6Ips, &ipAddrs)
+	ipAddrs := make([]*net.IPNet, 0, 2)
+	parseCIDRs(v4Ips, &ipAddrs)
+	parseCIDRs(v6Ips, &ipAddrs)
 
 	switch context {
 	case "up":
@@ -116,49 +126,60 @@ func main() {
 	}
 }
 
-func cleanIps(ips []string, outIps *[]string) {
-	for _, ip := range ips {
-		//Convert to IP without netmask.
-		index := strings.Index(ip, "/")
-		if index < 0 {
-			log.Print("Invalid IP/mask supplied: ", ip)
+// parseCIDRs converts a slice of string IPs to a slice of net.IPNet structs.
+// Continues over any invalid CIDRs.
+func parseCIDRs(cidrs []string, outIps *[]*net.IPNet) {
+	for _, cidr := range cidrs {
+		_, parsedCIDR, err := net.ParseCIDR(cidr)
+		if err != nil {
+			log.Print("Invalid CIDR for '", cidr, "': ", err)
 			continue
 		}
-
-		ip := ip[:index] //Strip subnet from IP
-		*outIps = append(*outIps, ip)
+		*outIps = append(*outIps, parsedCIDR)
 	}
-
 }
 
-func getRouteDev(ip string) string {
-	//Figure out interface to add proxy arp for
-	cmd := exec.Command("ip", "-o", "route", "get", ip)
-	stdoutStderr, err := cmd.CombinedOutput()
+// getRouteDev finds any local addressed interfaces whose subnet contains the targetIP.
+// Returns empty string if no match found. Returns error if parsing of targetIP or local interface
+// information fails
+func getRouteDev(targetIP net.IP) (string, error) {
+	interfaces, err := net.Interfaces()
 	if err != nil {
-		log.Print(err, string(stdoutStderr))
-		return ""
+		return "", err
 	}
 
-	parts := strings.Fields(string(stdoutStderr))
-	for index, val := range parts {
-		if val == "dev" {
-			devName := parts[index+1]
-			return devName
+	for _, iface := range interfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return "", err
+		}
+
+		for _, addr := range addrs {
+			_, IPNet, err := net.ParseCIDR(addr.String())
+			if err != nil {
+				return "", err
+			}
+			if IPNet.Contains(targetIP) {
+				return iface.Name, nil
+			}
 		}
 	}
 
-	return ""
+	//No local match found, meaning IP is probably routed to this host.
+	//No need for proxy ARP/NDP.
+	return "", nil
 }
 
+// activateProxyNdp sets up proxy NDP on the network device specified.
 func activateProxyNdp(dev string) error {
 	//Enable proxy ndp on  interface (needed before adding specific proxy entries)
 	proxyNdpFile := "/proc/sys/net/ipv6/conf/" + dev + "/proxy_ndp"
 	return ioutil.WriteFile(proxyNdpFile, []byte("1"), 0644)
 }
 
-func runUp(c *lxc.Container, ctName string, hostDevName string, ips []string, gwProxyDevs map[string]gwDev) {
-	log.Printf("LXC Net UP: %s %s %s", ctName, hostDevName, ips)
+// runUp called for each network interface that uses this hook script when the container comes up.
+func runUp(c *lxc.Container, ctName string, hostDevName string, cidrs []*net.IPNet, gwProxyDevs map[string]gwDev) {
+	log.Printf("LXC Net UP: %s %s %s", ctName, hostDevName, cidrs)
 
 	//Activate IPv6 proxy ndp on all interfaces to ensure IPv6 connectivity works.
 	//There is some unexpected behaviour when proxy ndp is only enabled on selected interfaces
@@ -181,12 +202,13 @@ func runUp(c *lxc.Container, ctName string, hostDevName string, ips []string, gw
 	}
 
 	//Add static route and proxy entry for each IP
-	for _, ip := range ips {
+	for _, cidr := range cidrs {
 		//Lookup current route dev so we can setup proxy arp/ndp.
-		routeDev := getRouteDev(ip)
+		ip := cidr.IP.String()
+		routeDev, err := getRouteDev(cidr.IP)
 
-		if routeDev == "" {
-			log.Fatal("Can't find route device for IP '", ip, "'")
+		if err != nil {
+			log.Fatal("Error finding route dev: '", ip, "': ", err)
 		}
 
 		cmd := exec.Command("ip", "route", "add", ip, "dev", hostDevName)
@@ -194,6 +216,10 @@ func runUp(c *lxc.Container, ctName string, hostDevName string, ips []string, gw
 			log.Fatal("Error adding static route for IP '", ip, "': ", err, " ", string(stdoutStderr))
 		}
 		log.Print("Added static route for IP ", ip, " to ", hostDevName)
+
+		if routeDev == "" {
+			continue //If not route dev found, IP is probably routed to this host.
+		}
 
 		cmd = exec.Command("ip", "neigh", "replace", "proxy", ip, "dev", routeDev)
 		if stdoutStderr, err := cmd.CombinedOutput(); err != nil {
@@ -204,23 +230,25 @@ func runUp(c *lxc.Container, ctName string, hostDevName string, ips []string, gw
 		//Send NDP or ARP (IPv6 and IPv4 respectively) adverts
 		if strings.Contains(ip, ":") {
 			if err := ndp.SendUnsolicited(routeDev, ip); err != nil {
-				log.Fatal("Error sending NDP for IP '", ip, " on iface ", routeDev, ": ", err)
+				log.Print("Error sending NDP for IP '", ip, " on iface ", routeDev, ": ", err)
 			}
 		} else {
 			if err := arp.SendUnsolicited(routeDev, ip); err != nil {
-				log.Fatal("Error sending ARP for IP '", ip, " on iface ", routeDev, ": ", err)
+				log.Print("Error sending ARP for IP '", ip, " on iface ", routeDev, ": ", err)
 			}
 		}
 
-		log.Print("Advertised NDP/ARP for IP '", ip, "' on ", routeDev)
+		log.Print("Advertised NDP/ARP for IP ", ip, " on ", routeDev)
 	}
 }
 
-func runDown(c *lxc.Container, ctName string, hostDevName string, ips []string) {
-	log.Printf("LXC Net Down: %s %s %s", ctName, hostDevName, ips)
+// runDown called for each network interface that uses this hook script when the container comes up.
+func runDown(c *lxc.Container, ctName string, hostDevName string, cidrs []*net.IPNet) {
+	log.Printf("LXC Net Down: %s %s %s", ctName, hostDevName, cidrs)
 
 	//Remove static route and proxy entry for each IP
-	for _, ip := range ips {
+	for _, cidr := range cidrs {
+		ip := cidr.IP.String()
 		cmd := exec.Command("ip", "route", "del", ip, "dev", hostDevName)
 		if stdoutStderr, err := cmd.CombinedOutput(); err != nil {
 			log.Fatal("Error deleting static route for IP '", ip, "': ", err, " ", string(stdoutStderr))
@@ -228,10 +256,15 @@ func runDown(c *lxc.Container, ctName string, hostDevName string, ips []string) 
 		log.Print("Deleted static route for IP ", ip, " to ", hostDevName)
 
 		//Now static route is removed, find original route dev so we can remove proxy arp/ndp config.
-		routeDev := getRouteDev(ip)
+		routeDev, err := getRouteDev(cidr.IP)
+
+		if err != nil {
+			log.Print("Error finding route dev: '", ip, "': ", err)
+			continue
+		}
 
 		if routeDev == "" {
-			continue
+			continue //Can't clean up proxy ARP/NDP rule if can't find route dev.
 		}
 
 		cmd = exec.Command("ip", "neigh", "del", "proxy", ip, "dev", routeDev)


### PR DESCRIPTION
- Modifies proxy ARP/NDP device detection to use local host interface IP addressing.
- This fixes an issue where if host uses IPv6 router advertisements there is not always a default route available when the containers start.
- Adds better comments.
- Renames process log prefix to lxc-routednet.

Signed-off-by: tomponline <tomp@tomp.uk>